### PR TITLE
[RFC] Fix vote up/down tooltips

### DIFF
--- a/src/app/retro-page/retro-page.component.html
+++ b/src/app/retro-page/retro-page.component.html
@@ -118,12 +118,12 @@
                             </span>
                         </button>
                         <button mat-mini-fab color="primary" class="message-action" (click)="thumbsDown(message)">
-                            <span class="material-icons" matTooltip="Vote up">
+                            <span class="material-icons" matTooltip="Vote down">
                                 thumb_down
                             </span>
                         </button>
                         <button mat-mini-fab color="primary" class="message-action" (click)="thumbsUp(message)">
-                            <span class="material-icons" matTooltip="Vote down">
+                            <span class="material-icons" matTooltip="Vote up">
                                 thumb_up
                             </span>
                         </button>


### PR DESCRIPTION
Fixes the inverted "Vote up" and "Vote down" tooltips in the retro-page